### PR TITLE
Modify module name to match the repository URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/yusufpapurcu/wmi
 
-go 1.13
+go 1.16
 
 require github.com/go-ole/go-ole v1.2.6


### PR DESCRIPTION
In order to be able to install this module instead of the one defined at StackExchange/wmi, the module name needs to be modified. Otherwise the following issue happens:
```
go: github.com/yusufpapurcu/wmi@v1.2.1: parsing go.mod:
        module declares its path as: github.com/StackExchange/wmi
                but was required as: github.com/yusufpapurcu/wmi
```