### PR TITLE
Allow missing and null pointer fields to be nil.

### DIFF
--- a/swbemservices.go
+++ b/swbemservices.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wmi

--- a/swbemservices_test.go
+++ b/swbemservices_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package wmi
@@ -103,8 +104,8 @@ func WbemGetMemoryUsageMB(s *SWbemServices) (float64, float64, float64) {
 //Run all benchmarks (should run for at least 60s to get a stable number):
 //go test -run=NONE -bench=Version -benchtime=120s
 
-//Individual benchmarks:
-//go test -run=NONE -bench=NewVersion -benchtime=120s
+// Individual benchmarks:
+// go test -run=NONE -bench=NewVersion -benchtime=120s
 func BenchmarkNewVersion(b *testing.B) {
 	s, err := InitializeSWbemServices(DefaultClient)
 	if err != nil {
@@ -128,7 +129,7 @@ func BenchmarkNewVersion(b *testing.B) {
 	}
 }
 
-//go test -run=NONE -bench=OldVersion -benchtime=120s
+// go test -run=NONE -bench=OldVersion -benchtime=120s
 func BenchmarkOldVersion(b *testing.B) {
 	var dst []Win32_OperatingSystem
 	q := CreateQuery(&dst, "")

--- a/wmi.go
+++ b/wmi.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*
@@ -20,7 +21,6 @@ Example code to print names of running processes:
 			println(i, v.Name)
 		}
 	}
-
 */
 package wmi
 
@@ -338,11 +338,6 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 		f := v.Field(i)
 		of := f
 		isPtr := f.Kind() == reflect.Ptr
-		if isPtr {
-			ptr := reflect.New(f.Type().Elem())
-			f.Set(ptr)
-			f = f.Elem()
-		}
 		n := v.Type().Field(i).Name
 		if n[0] < 'A' || n[0] > 'Z' {
 			continue
@@ -366,6 +361,12 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 			continue
 		}
 		defer prop.Clear()
+
+		if isPtr && !(c.PtrNil && prop.VT == 0x1) {
+			ptr := reflect.New(f.Type().Elem())
+			f.Set(ptr)
+			f = f.Elem()
+		}
 
 		if prop.VT == 0x1 { //VT_NULL
 			continue


### PR DESCRIPTION
This commit ensures missing fields for pointer field types remain nil:

  * This allows one to distinguish the property wasn't present from the property being NULL when the PtrNil option is false.
  * This also makes it more convenient to reuse structs with pointer field types with various encoders like the standard library JSON marshaler, where you may want to omit a field if it didn't exist in the queried results.

The expectations around this change are captured in the TestMissingFields test.

In addition, it also fixes an edge case where even with PtrNil set to true, pointer field types would always return with a pointer to a zero value instead of being nil even when the query property's value is VT_NULL.

This fix is checked by the TestNullPointerField test.

These changes provide a bit more flexibility when utilizing custom queries with classes that may have different fields on different versions of Windows.