### PR TITLE
Added float64 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bilinenkisi""""""""""""""""""""""""""""/wmi
+module github.com/yusufpapurcu/wmi
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yusufpapurcu/wmi
+module github.com/bilinenkisi""""""""""""""""""""""""""""/wmi
 
 go 1.16
 

--- a/wmi.go
+++ b/wmi.go
@@ -456,6 +456,18 @@ func (c *Client) loadEntity(dst interface{}, src *ole.IDispatch) (errFieldMismat
 					Reason:     "not a Float32",
 				}
 			}
+		case float64:
+			switch f.Kind() {
+			case reflect.Float32, reflect.Float64:
+				f.SetFloat(val)
+			default:
+				return &ErrFieldMismatch{
+					StructType: of.Type(),
+					FieldName:  n,
+					Reason:     "not a Float64",
+				}
+			}
+		
 		default:
 			if f.Kind() == reflect.Slice {
 				switch f.Type().Elem().Kind() {


### PR DESCRIPTION
When i tried to use wmi.QueryNameSpace for Win32_ReliabilityStabilityMetrics with this struct:
```go
type Win32_ReliabilityStabilityMetrics struct {
	EndMeasurementDate   time.Time `json:"end_measurement_date"`
	RelID                string    `json:"rel_id"`
	StartMeasurementDate time.Time `json:"start_measurement_date"`
	SystemStabilityIndex float64   `json:"system_stability_index"`
	TimeGenerated        time.Time `json:"time_generated"`
}
```
I got error for SystemStabilityIndex field: `cannot load field "SystemStabilityIndex" into a "float64": unsupported type (float64)`
even if i used float32 to fetch data, this time i got this error: `Özel durum oluştu. (Nesne sunucuya bağlanmamış )` and also for other variable types was same that are supported by the package. So, i added float64 support.
